### PR TITLE
girdSplitter resize behavior corrected

### DIFF
--- a/Gui.xaml
+++ b/Gui.xaml
@@ -355,7 +355,7 @@
                     </localcon:ImageCanvas>
                 </ScrollViewer>
             </DockPanel>
-            <GridSplitter x:Name="gridSplitter" Width="5" Grid.Column="1"/>
+            <GridSplitter x:Name="gridSplitter" Width="5" Grid.Column="1" HorizontalAlignment="Center" ResizeBehavior="PreviousAndNext"/>
             <DockPanel LastChildFill="True" Grid.Column="2" >
                 <ToolBar x:Name="toolBar2" DockPanel.Dock="Top" HorizontalAlignment="Stretch">
                     <Button x:Name="buttonOCR" VerticalAlignment="Top" Click="buttonOCR_Click" ToolTip="{x:Static resx:Gui.toolStripBtnOCR_ToolTipText}">


### PR DESCRIPTION
the WPF form of the project has this bug on gridsplitter's default behavior. if you are not aware of, try resizing it.
Values are paired to be Left/PreviousAndCurrent, Center/PreviousAndNext and Right/CurrentAndNext to give correct behavior.