### PR TITLE
Cleaned up Location, Size and ClientSize definitions

### DIFF
--- a/BulkDialog.resx
+++ b/BulkDialog.resx
@@ -122,14 +122,8 @@
     <value>NoControl</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="labelOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
   <data name="textBoxInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
-  </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 105</value>
   </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -150,9 +144,6 @@
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
   </data>
-  <data name="btnInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>365, 23</value>
-  </data>
   <data name="textBoxInput.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
   </data>
@@ -162,17 +153,11 @@
   <data name="comboBoxOutputFormat.Items" xml:space="preserve">
     <value>text</value>
   </data>
-  <data name="textBoxInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 26</value>
-  </data>
   <data name="comboBoxOutputFormat.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
-  </data>
-  <data name="labelInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 30</value>
   </data>
   <data name="labelOutput.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -189,23 +174,8 @@
   <data name="buttonRun.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="labelOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>15, 62</value>
-  </data>
-  <data name="comboBoxOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 105</value>
-  </data>
-  <data name="textBoxInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
   <data name="labelInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="comboBoxOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 24</value>
-  </data>
-  <data name="buttonRun.Location" type="System.Drawing.Point, System.Drawing">
-    <value>197, 105</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -215,9 +185,6 @@
   </data>
   <data name="btnOutput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 17</value>
   </data>
   <data name="btnInput.ToolTip" xml:space="preserve">
     <value />
@@ -234,9 +201,6 @@
   <data name="labelInput.Text" xml:space="preserve">
     <value>Input Folder:</value>
   </data>
-  <data name="btnOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 28</value>
-  </data>
   <data name="labelOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
@@ -249,9 +213,6 @@
   <data name="textBoxOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
-  <data name="textBoxOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>115, 58</value>
-  </data>
   <data name="comboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
   </data>
@@ -263,15 +224,6 @@
   </data>
   <data name="labelOutputFormat.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="btnInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 28</value>
-  </data>
-  <data name="btnOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>365, 55</value>
-  </data>
-  <data name="labelOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
   </data>
   <data name="labelInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>
@@ -291,29 +243,17 @@
   <data name="labelInput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 28</value>
-  </data>
-  <data name="labelOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 108</value>
-  </data>
   <data name="textBoxOutput.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
   <data name="buttonRun.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="textBoxOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
   <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
   <data name="this.Title" xml:space="preserve">
     <value>Bulk OCR</value>
-  </data>
-  <data name="buttonRun.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 28</value>
   </data>
   <data name="comboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -323,9 +263,6 @@
   </data>
   <data name="btnOutput.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
-  </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>423, 155</value>
   </data>
   <data name="buttonRun.Text" xml:space="preserve">
     <value>Run</value>

--- a/ChangeCaseDialog.resx
+++ b/ChangeCaseDialog.resx
@@ -125,9 +125,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>172, 169</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -135,23 +132,11 @@
   <data name="this.Title" xml:space="preserve">
     <value>Change Case</value>
   </data>
-  <data name="buttonChange.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 132</value>
-  </data>
-  <data name="buttonChange.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
   <data name="buttonChange.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
   <data name="buttonChange.Text" xml:space="preserve">
     <value>Change</value>
-  </data>
-  <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>89, 132</value>
-  </data>
-  <data name="buttonClose.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
   </data>
   <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -159,23 +144,11 @@
   <data name="buttonClose.Text" xml:space="preserve">
     <value>Close</value>
   </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 1</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 118</value>
-  </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
   <data name="radioButton1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="radioButton1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 19</value>
-  </data>
-  <data name="radioButton1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 17</value>
   </data>
   <data name="radioButton1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -185,12 +158,6 @@
   </data>
   <data name="radioButton2.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="radioButton2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 42</value>
-  </data>
-  <data name="radioButton2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 17</value>
   </data>
   <data name="radioButton2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -204,12 +171,6 @@
   <data name="radioButton3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="radioButton3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 65</value>
-  </data>
-  <data name="radioButton3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
-  </data>
   <data name="radioButton3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
@@ -221,12 +182,6 @@
   </data>
   <data name="radioButton4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="radioButton4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 90</value>
-  </data>
-  <data name="radioButton4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
   </data>
   <data name="radioButton4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>

--- a/DownloadDialog.resx
+++ b/DownloadDialog.resx
@@ -128,9 +128,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>263, 180</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -144,12 +141,6 @@
   <data name="buttonCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 54</value>
-  </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
@@ -158,12 +149,6 @@
   </data>
   <data name="buttonClose.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="buttonClose.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 109</value>
-  </data>
-  <data name="buttonClose.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
   </data>
   <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -177,23 +162,11 @@
   <data name="buttonDownload.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="buttonDownload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 25</value>
-  </data>
-  <data name="buttonDownload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
   <data name="buttonDownload.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="buttonDownload.Text" xml:space="preserve">
     <value>Download</value>
-  </data>
-  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
-  </data>
-  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 142</value>
   </data>
   <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -201,31 +174,13 @@
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Available Languages</value>
   </data>
-  <data name="listBox1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 18</value>
-  </data>
-  <data name="listBox1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>152, 121</value>
-  </data>
   <data name="listBox1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
-  </data>
-  <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 158</value>
-  </data>
-  <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>263, 22</value>
   </data>
   <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
-  <data name="toolStripProgressBar1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 16</value>
-  </data>
   <data name="toolStripProgressBar1.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="toolStripStatusLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 17</value>
   </data>
 </root>

--- a/ImageInfoDialog.resx
+++ b/ImageInfoDialog.resx
@@ -125,21 +125,12 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>235, 202</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
   <data name="this.Title" xml:space="preserve">
     <value>Image Properties</value>
-  </data>
-  <data name="buttonOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>80, 160</value>
-  </data>
-  <data name="buttonOK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
   </data>
   <data name="buttonOK.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -156,12 +147,6 @@
   <data name="comboBox3.Items2" xml:space="preserve">
     <value>cm</value>
   </data>
-  <data name="comboBox3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 19</value>
-  </data>
-  <data name="comboBox3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 21</value>
-  </data>
   <data name="comboBox3.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
@@ -174,23 +159,11 @@
   <data name="comboBox4.Items2" xml:space="preserve">
     <value>cm</value>
   </data>
-  <data name="comboBox4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 44</value>
-  </data>
-  <data name="comboBox4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 21</value>
-  </data>
   <data name="comboBox4.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
   </data>
   <data name="label5.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>145, 74</value>
-  </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 13</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -204,12 +177,6 @@
   <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>145, 100</value>
-  </data>
-  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>25, 13</value>
-  </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
@@ -222,12 +189,6 @@
   <data name="labelBitDepth.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="labelBitDepth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 126</value>
-  </data>
-  <data name="labelBitDepth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>51, 13</value>
-  </data>
   <data name="labelBitDepth.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
@@ -236,12 +197,6 @@
   </data>
   <data name="labelHeight.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 48</value>
-  </data>
-  <data name="labelHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
   </data>
   <data name="labelHeight.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -252,12 +207,6 @@
   <data name="labelWidth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 22</value>
-  </data>
-  <data name="labelWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
-  </data>
   <data name="labelWidth.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
@@ -266,12 +215,6 @@
   </data>
   <data name="labelXRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelXRes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 74</value>
-  </data>
-  <data name="labelXRes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
   </data>
   <data name="labelXRes.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -282,59 +225,23 @@
   <data name="labelYRes.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelYRes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 100</value>
-  </data>
-  <data name="labelYRes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 13</value>
-  </data>
   <data name="labelYRes.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="labelYRes.Text" xml:space="preserve">
     <value>Y-Resolution</value>
   </data>
-  <data name="textBoxBitDepth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 123</value>
-  </data>
-  <data name="textBoxBitDepth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 20</value>
-  </data>
   <data name="textBoxBitDepth.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
-  </data>
-  <data name="textBoxHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 45</value>
-  </data>
-  <data name="textBoxHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 20</value>
   </data>
   <data name="textBoxHeight.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
   </data>
-  <data name="textBoxWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 19</value>
-  </data>
-  <data name="textBoxWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 20</value>
-  </data>
   <data name="textBoxWidth.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
-  <data name="textBoxXRes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 71</value>
-  </data>
-  <data name="textBoxXRes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 20</value>
-  </data>
   <data name="textBoxXRes.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="textBoxYRes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 97</value>
-  </data>
-  <data name="textBoxYRes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 20</value>
   </data>
   <data name="textBoxYRes.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>

--- a/OptionsDialog.resx
+++ b/OptionsDialog.resx
@@ -124,9 +124,6 @@
     <value />
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="buttonOK.Location" type="System.Drawing.Point, System.Drawing">
-    <value>192, 167</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="tabControl1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -141,26 +138,17 @@
   <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="checkBoxDangAmbigs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
-  </data>
   <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
   <data name="tabPage2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
-  <data name="textBoxWatch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
   <data name="labelWatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="labelWatch.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="btnWatch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 28</value>
   </data>
   <data name="comboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -174,26 +162,17 @@
   <data name="comboBoxOutputFormat.Items2" xml:space="preserve">
     <value>hocr</value>
   </data>
-  <data name="btnOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 28</value>
-  </data>
   <data name="checkBoxWatch.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="labelOutput.Text" xml:space="preserve">
     <value>Output Folder:</value>
   </data>
-  <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
   <data name="btnDangAmbigs.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
   <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
-  </data>
-  <data name="checkBoxDangAmbigs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 63</value>
   </data>
   <data name="this.Title" xml:space="preserve">
     <value>Options</value>
@@ -204,29 +183,14 @@
   <data name="labelWatch.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
-  <data name="textBoxOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
   <data name="comboBoxOutputFormat.Items" xml:space="preserve">
     <value>text</value>
   </data>
   <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="textBoxWatch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 16</value>
-  </data>
-  <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 129</value>
-  </data>
-  <data name="labelPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
   <data name="labelOutputFormat.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelWatch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 20</value>
   </data>
   <data name="labelOutput.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -237,17 +201,8 @@
   <data name="textBoxDangAmbigs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
-  <data name="labelOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 92</value>
-  </data>
   <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
-  </data>
-  <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 25</value>
-  </data>
-  <data name="textBoxOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 48</value>
   </data>
   <data name="comboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -255,17 +210,8 @@
   <data name="textBoxDangAmbigs.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="comboBoxOutputFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>105, 86</value>
-  </data>
-  <data name="labelOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
   <data name="textBoxOutput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="checkBoxWatch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>74, 21</value>
   </data>
   <data name="btnWatch.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -275,9 +221,6 @@
   </data>
   <data name="labelPath.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
-  </data>
-  <data name="labelWatch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 17</value>
   </data>
   <data name="btnDangAmbigs.ToolTip" xml:space="preserve">
     <value />
@@ -300,9 +243,6 @@
   <data name="checkBoxDangAmbigs.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>408, 129</value>
-  </data>
   <data name="checkBoxWatch.ToolTip" xml:space="preserve">
     <value />
   </data>
@@ -318,15 +258,6 @@
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>300, 167</value>
-  </data>
-  <data name="labelOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 17</value>
-  </data>
-  <data name="comboBoxOutputFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 24</value>
-  </data>
   <data name="labelOutputFormat.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -335,9 +266,6 @@
   </data>
   <data name="checkBoxWatch.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
-  </data>
-  <data name="textBoxDangAmbigs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 18</value>
   </data>
   <data name="tabPage1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
@@ -351,14 +279,8 @@
   <data name="checkBoxDangAmbigs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="btnOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 46</value>
-  </data>
   <data name="openFileDialog1.Filter" xml:space="preserve">
     <value>Text Files (*.txt)|*.txt</value>
-  </data>
-  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
   </data>
   <data name="buttonCancel.ToolTip" xml:space="preserve">
     <value />
@@ -381,9 +303,6 @@
   <data name="labelOutputFormat.Text" xml:space="preserve">
     <value>Output Format</value>
   </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 28</value>
-  </data>
   <data name="checkBoxDangAmbigs.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
@@ -393,9 +312,6 @@
   <data name="labelPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="textBoxDangAmbigs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>241, 22</value>
-  </data>
   <data name="btnDangAmbigs.Text" xml:space="preserve">
     <value>...</value>
   </data>
@@ -404,9 +320,6 @@
   </data>
   <data name="labelOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 52</value>
   </data>
   <data name="btnWatch.ToolTip" xml:space="preserve">
     <value />
@@ -423,9 +336,6 @@
   <data name="labelPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>
   </data>
-  <data name="btnDangAmbigs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 16</value>
-  </data>
   <data name="labelOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
@@ -438,32 +348,17 @@
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="buttonOK.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 28</value>
-  </data>
-  <data name="labelPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 17</value>
-  </data>
   <data name="btnOutput.Text" xml:space="preserve">
     <value>...</value>
   </data>
   <data name="checkBoxDangAmbigs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>416, 207</value>
-  </data>
   <data name="btnOutput.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
   <data name="checkBoxWatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="btnWatch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>355, 14</value>
-  </data>
-  <data name="checkBoxWatch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 91</value>
   </data>
   <data name="labelWatch.Text" xml:space="preserve">
     <value>Watch Folder:</value>
@@ -489,9 +384,6 @@
   <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>416, 158</value>
-  </data>
   <data name="buttonOK.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 4, 4, 4</value>
   </data>
@@ -503,9 +395,6 @@
   </data>
   <data name="buttonOK.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="btnDangAmbigs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 28</value>
   </data>
   <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>

--- a/SliderDialog.resx
+++ b/SliderDialog.resx
@@ -125,9 +125,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>226, 123</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -135,23 +132,11 @@
   <data name="this.Title" xml:space="preserve">
     <value>Image Control</value>
   </data>
-  <data name="buttonApply.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 76</value>
-  </data>
-  <data name="buttonApply.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
   <data name="buttonApply.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="buttonApply.Text" xml:space="preserve">
     <value>Apply</value>
-  </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>122, 76</value>
-  </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
   </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -162,23 +147,11 @@
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>26, 13</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>33, 13</value>
-  </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Label</value>
-  </data>
-  <data name="trackBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>29, 34</value>
-  </data>
-  <data name="trackBar1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>168, 45</value>
   </data>
   <data name="trackBar1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>

--- a/SplitPdfDialog.resx
+++ b/SplitPdfDialog.resx
@@ -128,9 +128,6 @@
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>274, 178</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
@@ -141,12 +138,6 @@
   <data name="this.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="buttonBrowseInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 19</value>
-  </data>
-  <data name="buttonBrowseInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>27, 23</value>
-  </data>
   <data name="buttonBrowseInput.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
   </data>
@@ -155,12 +146,6 @@
   </data>
   <data name="buttonBrowseInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="buttonBrowseOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 45</value>
-  </data>
-  <data name="buttonBrowseOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>27, 23</value>
   </data>
   <data name="buttonBrowseOutput.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -171,12 +156,6 @@
   <data name="buttonBrowseOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="buttonCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>174, 135</value>
-  </data>
-  <data name="buttonCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
-  </data>
   <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
@@ -185,12 +164,6 @@
   </data>
   <data name="buttonCancel.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="buttonSplit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>93, 135</value>
-  </data>
-  <data name="buttonSplit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
   </data>
   <data name="buttonSplit.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -204,12 +177,6 @@
   <data name="labelFrom.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelFrom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>121, 82</value>
-  </data>
-  <data name="labelFrom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 13</value>
-  </data>
   <data name="labelFrom.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
@@ -221,12 +188,6 @@
   </data>
   <data name="labelInput.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 24</value>
-  </data>
-  <data name="labelInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>34, 13</value>
   </data>
   <data name="labelInput.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -240,12 +201,6 @@
   <data name="labelNumOfPages.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelNumOfPages.Location" type="System.Drawing.Point, System.Drawing">
-    <value>83, 105</value>
-  </data>
-  <data name="labelNumOfPages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 13</value>
-  </data>
   <data name="labelNumOfPages.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
   </data>
@@ -257,12 +212,6 @@
   </data>
   <data name="labelOutput.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="labelOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>19, 50</value>
-  </data>
-  <data name="labelOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
   </data>
   <data name="labelOutput.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -276,12 +225,6 @@
   <data name="labelTo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="labelTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>189, 82</value>
-  </data>
-  <data name="labelTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>19, 13</value>
-  </data>
   <data name="labelTo.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
   </data>
@@ -293,12 +236,6 @@
   </data>
   <data name="radioButtonFiles.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
-  </data>
-  <data name="radioButtonFiles.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 103</value>
-  </data>
-  <data name="radioButtonFiles.Size" type="System.Drawing.Size, System.Drawing">
-    <value>46, 17</value>
   </data>
   <data name="radioButtonFiles.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -312,12 +249,6 @@
   <data name="radioButtonPages.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="radioButtonPages.Location" type="System.Drawing.Point, System.Drawing">
-    <value>28, 80</value>
-  </data>
-  <data name="radioButtonPages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>55, 17</value>
-  </data>
   <data name="radioButtonPages.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
   </data>
@@ -327,35 +258,17 @@
   <data name="radioButtonPages.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxFrom.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 77</value>
-  </data>
-  <data name="textBoxFrom.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 20</value>
-  </data>
   <data name="textBoxFrom.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="textBoxFrom.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>63, 21</value>
-  </data>
-  <data name="textBoxInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 20</value>
-  </data>
   <data name="textBoxInput.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
   </data>
   <data name="textBoxInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="textBoxNumOfPages.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 100</value>
-  </data>
-  <data name="textBoxNumOfPages.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 20</value>
   </data>
   <data name="textBoxNumOfPages.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -366,23 +279,11 @@
   <data name="textBoxNumOfPages.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxOutput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>63, 47</value>
-  </data>
-  <data name="textBoxOutput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 20</value>
-  </data>
   <data name="textBoxOutput.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
   <data name="textBoxOutput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="textBoxTo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>211, 77</value>
-  </data>
-  <data name="textBoxTo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 20</value>
   </data>
   <data name="textBoxTo.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>


### PR DESCRIPTION
Not sure if I could've removed more obsolete entries, so this only removes Location, Size and ClientSize ones.