### PR TITLE
Remove more unnecessary entries from localizable resx files

### DIFF
--- a/BulkDialog.resx
+++ b/BulkDialog.resx
@@ -118,52 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="labelOutput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="textBoxInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnInput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
   <data name="textBoxOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="buttonRun.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="textBoxInput.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>8, 16</value>
-  </data>
   <data name="comboBoxOutputFormat.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
-  <data name="labelOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="btnOutput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
   <data name="buttonCancel.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="buttonRun.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
   </data>
   <data name="buttonRun.ToolTip" xml:space="preserve">
     <value />
@@ -183,14 +147,8 @@
   <data name="btnInput.ToolTip" xml:space="preserve">
     <value>Browse</value>
   </data>
-  <data name="labelOutputFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>24</value>
-  </data>
   <data name="textBoxInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelOutput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
   </data>
   <data name="labelInput.Text" xml:space="preserve">
     <value>Input Folder:</value>
@@ -201,59 +159,11 @@
   <data name="btnOutput.Text" xml:space="preserve">
     <value>...</value>
   </data>
-  <data name="textBoxOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="comboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>23</value>
-  </data>
-  <data name="btnInput.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="labelOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelOutputFormat.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="buttonCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelInput.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
   <data name="labelOutputFormat.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="labelInput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="textBoxOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="buttonRun.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Bulk OCR</value>
-  </data>
-  <data name="comboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
   </data>
   <data name="buttonRun.Text" xml:space="preserve">
     <value>Run</value>
@@ -261,23 +171,8 @@
   <data name="labelOutput.Text" xml:space="preserve">
     <value>Output Folder:</value>
   </data>
-  <data name="btnOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <data name="labelOutputFormat.Text" xml:space="preserve">
     <value>Output Format</value>
-  </data>
-  <data name="labelOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>186, 17</value>
-  </data>
-  <data name="folderBrowserDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>17, 17</value>
   </data>
   <data name="checkBoxDeskew.Text" xml:space="preserve">
     <value>Deskew</value>

--- a/ChangeCaseDialog.resx
+++ b/ChangeCaseDialog.resx
@@ -118,73 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Change Case</value>
-  </data>
-  <data name="buttonChange.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
   </data>
   <data name="buttonChange.Text" xml:space="preserve">
     <value>Change</value>
   </data>
-  <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
   <data name="buttonClose.Text" xml:space="preserve">
     <value>Close</value>
-  </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="radioButton1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButton1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
   </data>
   <data name="radioButton1.Text" xml:space="preserve">
     <value>Sentence case</value>
   </data>
-  <data name="radioButton2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButton2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
   <data name="radioButton2.Text" xml:space="preserve">
     <value>lower case</value>
   </data>
-  <data name="radioButton3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButton3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="radioButton3.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="radioButton3.Text" xml:space="preserve">
     <value>UPPER CASE</value>
-  </data>
-  <data name="radioButton4.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButton4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="radioButton4.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
   </data>
   <data name="radioButton4.Text" xml:space="preserve">
     <value>Title Case</value>

--- a/DownloadDialog.resx
+++ b/DownloadDialog.resx
@@ -118,69 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>0, 158</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Download Language Data</value>
-  </data>
-  <data name="buttonCancel.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="buttonCancel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="buttonClose.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonClose.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="buttonClose.Text" xml:space="preserve">
     <value>Close</value>
-  </data>
-  <data name="buttonDownload.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="buttonDownload.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="buttonDownload.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="buttonDownload.Text" xml:space="preserve">
     <value>Download</value>
   </data>
-  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
   <data name="groupBox1.Text" xml:space="preserve">
     <value>Available Languages</value>
-  </data>
-  <data name="listBox1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="toolStripProgressBar1.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
   </data>
 </root>

--- a/ImageInfoDialog.resx
+++ b/ImageInfoDialog.resx
@@ -118,22 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Image Properties</value>
-  </data>
-  <data name="buttonOK.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
   </data>
   <data name="buttonOK.Text" xml:space="preserve">
     <value>OK</value>
@@ -147,9 +135,6 @@
   <data name="comboBox3.Items2" xml:space="preserve">
     <value>cm</value>
   </data>
-  <data name="comboBox3.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
   <data name="comboBox4.Items" xml:space="preserve">
     <value>pixels</value>
   </data>
@@ -159,92 +144,26 @@
   <data name="comboBox4.Items2" xml:space="preserve">
     <value>cm</value>
   </data>
-  <data name="comboBox4.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
   <data name="label5.Text" xml:space="preserve">
     <value>DPI</value>
-  </data>
-  <data name="label6.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label6.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>DPI</value>
   </data>
-  <data name="labelBitDepth.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelBitDepth.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="labelBitDepth.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
   <data name="labelBitDepth.Text" xml:space="preserve">
     <value>Bit Depth</value>
-  </data>
-  <data name="labelHeight.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelHeight.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
   </data>
   <data name="labelHeight.Text" xml:space="preserve">
     <value>Height</value>
   </data>
-  <data name="labelWidth.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelWidth.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
   <data name="labelWidth.Text" xml:space="preserve">
     <value>Width</value>
-  </data>
-  <data name="labelXRes.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelXRes.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="labelXRes.Text" xml:space="preserve">
     <value>X-Resolution</value>
   </data>
-  <data name="labelYRes.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelYRes.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
   <data name="labelYRes.Text" xml:space="preserve">
     <value>Y-Resolution</value>
-  </data>
-  <data name="textBoxBitDepth.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="textBoxHeight.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="textBoxWidth.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="textBoxXRes.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="textBoxYRes.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
   </data>
   <data name="comboBoxUnitH.ToolTip" xml:space="preserve">
     <value>Unit</value>

--- a/OptionsDialog.resx
+++ b/OptionsDialog.resx
@@ -124,33 +124,12 @@
     <value>Browse</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tabControl1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnDangAmbigs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <data name="btnWatch.Text" xml:space="preserve">
     <value>...</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="tabPage2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="labelWatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
   <data name="labelWatch.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="comboBoxOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
   </data>
   <data name="tabPage2.ToolTip" xml:space="preserve">
     <value />
@@ -158,17 +137,8 @@
   <data name="tabControl1.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="checkBoxWatch.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="labelOutput.Text" xml:space="preserve">
     <value>Output Folder:</value>
-  </data>
-  <data name="btnDangAmbigs.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="buttonCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
   </data>
   <data name="this.Title" xml:space="preserve">
     <value>Options</value>
@@ -176,29 +146,11 @@
   <data name="checkBoxDangAmbigs.Text" xml:space="preserve">
     <value>Enable</value>
   </data>
-  <data name="labelWatch.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="labelOutputFormat.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="labelOutput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="textBoxWatch.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="textBoxDangAmbigs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="comboBoxOutputFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
   </data>
   <data name="textBoxDangAmbigs.ToolTip" xml:space="preserve">
     <value />
@@ -206,68 +158,17 @@
   <data name="textBoxOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="btnWatch.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="labelOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="labelPath.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
   <data name="btnDangAmbigs.ToolTip" xml:space="preserve">
     <value>Browse</value>
   </data>
-  <data name="buttonOK.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
   <data name="labelPath.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnDangAmbigs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="checkBoxDangAmbigs.ToolTip" xml:space="preserve">
     <value />
   </data>
   <data name="checkBoxWatch.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="btnWatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="btnOutput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="textBoxOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
-  <data name="labelOutputFormat.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelPath.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxWatch.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="tabPage1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnOutput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="labelWatch.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="checkBoxDangAmbigs.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="openFileDialog1.Filter" xml:space="preserve">
     <value>Text Files (*.txt)|*.txt</value>
@@ -284,38 +185,14 @@
   <data name="labelPath.Text" xml:space="preserve">
     <value>Path:</value>
   </data>
-  <data name="checkBoxWatch.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="textBoxWatch.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
   <data name="labelOutputFormat.Text" xml:space="preserve">
     <value>Output Format</value>
-  </data>
-  <data name="checkBoxDangAmbigs.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="textBoxOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="labelPath.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="btnDangAmbigs.Text" xml:space="preserve">
     <value>...</value>
   </data>
-  <data name="btnWatch.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="labelOutputFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
   <data name="btnWatch.ToolTip" xml:space="preserve">
     <value>Browse</value>
-  </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
   </data>
   <data name="tabPage2.Text" xml:space="preserve">
     <value>DangAmbigs.txt</value>
@@ -323,81 +200,24 @@
   <data name="tabPage1.Text" xml:space="preserve">
     <value>Watch</value>
   </data>
-  <data name="labelPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
   <data name="labelOutput.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>8, 16</value>
-  </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="btnOutput.Text" xml:space="preserve">
     <value>...</value>
   </data>
-  <data name="checkBoxDangAmbigs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="btnOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="checkBoxWatch.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
   <data name="labelWatch.Text" xml:space="preserve">
     <value>Watch Folder:</value>
-  </data>
-  <data name="labelWatch.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="textBoxDangAmbigs.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="labelOutput.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="checkBoxDangAmbigs.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="textBoxWatch.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="buttonOK.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 4, 4, 4</value>
-  </data>
-  <data name="labelOutputFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
   </data>
   <data name="buttonOK.Text" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="buttonOK.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>186, 17</value>
-  </data>
-  <data name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>326, 17</value>
-  </data>
-  <data name="folderBrowserDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>17, 17</value>
   </data>
   <data name="checkBoxRemoveHyphens.Text" xml:space="preserve">
     <value>Remove soft hyphens</value>

--- a/SliderDialog.resx
+++ b/SliderDialog.resx
@@ -118,42 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Image Control</value>
-  </data>
-  <data name="buttonApply.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="buttonApply.Text" xml:space="preserve">
     <value>Apply</value>
   </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
   </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Label</value>
-  </data>
-  <data name="trackBar1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
   </data>
 </root>

--- a/SplitPdfDialog.resx
+++ b/SplitPdfDialog.resx
@@ -118,28 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.Localizable" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
-    <value>17, 17</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
   <data name="this.Title" xml:space="preserve">
     <value>Split PDF</value>
   </data>
   <data name="this.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="buttonBrowseInput.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
   </data>
   <data name="buttonBrowseInput.Text" xml:space="preserve">
     <value>...</value>
@@ -147,17 +132,11 @@
   <data name="buttonBrowseInput.ToolTip" xml:space="preserve">
     <value>Browse</value>
   </data>
-  <data name="buttonBrowseOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
   <data name="buttonBrowseOutput.Text" xml:space="preserve">
     <value>...</value>
   </data>
   <data name="buttonBrowseOutput.ToolTip" xml:space="preserve">
     <value>Browse</value>
-  </data>
-  <data name="buttonCancel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>Cancel</value>
@@ -165,20 +144,11 @@
   <data name="buttonCancel.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="buttonSplit.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
   <data name="buttonSplit.Text" xml:space="preserve">
     <value>Split</value>
   </data>
   <data name="buttonSplit.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelFrom.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelFrom.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
   </data>
   <data name="labelFrom.Text" xml:space="preserve">
     <value>from:</value>
@@ -186,23 +156,11 @@
   <data name="labelFrom.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="labelInput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelInput.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
   <data name="labelInput.Text" xml:space="preserve">
     <value>Input:</value>
   </data>
   <data name="labelInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelNumOfPages.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelNumOfPages.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
   </data>
   <data name="labelNumOfPages.Text" xml:space="preserve">
     <value>Number of pages per file:</value>
@@ -210,23 +168,11 @@
   <data name="labelNumOfPages.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="labelOutput.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
   <data name="labelOutput.Text" xml:space="preserve">
     <value>Output:</value>
   </data>
   <data name="labelOutput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="labelTo.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="labelTo.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
   </data>
   <data name="labelTo.Text" xml:space="preserve">
     <value>to:</value>
@@ -234,23 +180,11 @@
   <data name="labelTo.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="radioButtonFiles.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButtonFiles.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
   <data name="radioButtonFiles.Text" xml:space="preserve">
     <value>Files</value>
   </data>
   <data name="radioButtonFiles.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="radioButtonPages.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="radioButtonPages.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
   </data>
   <data name="radioButtonPages.Text" xml:space="preserve">
     <value>Pages</value>
@@ -258,20 +192,11 @@
   <data name="radioButtonPages.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxFrom.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
   <data name="textBoxFrom.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxInput.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
   <data name="textBoxInput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="textBoxNumOfPages.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
   </data>
   <data name="textBoxNumOfPages.Text" xml:space="preserve">
     <value>15</value>
@@ -279,14 +204,8 @@
   <data name="textBoxNumOfPages.ToolTip" xml:space="preserve">
     <value />
   </data>
-  <data name="textBoxOutput.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
   <data name="textBoxOutput.ToolTip" xml:space="preserve">
     <value />
-  </data>
-  <data name="textBoxTo.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
   </data>
   <data name="textBoxTo.ToolTip" xml:space="preserve">
     <value />


### PR DESCRIPTION
More strings removed.

One thing that's still bothering me is Gui.resx. Would it be OK to remove embedded icons from this file? Could you use them without embedding? Because I imported files into Transifex yesterday, and all of these icons are presented for localization there. It's crazy,